### PR TITLE
Argument completers

### DIFF
--- a/PurpleDevTools/Public/Get-CommentBasedHelp.ps1
+++ b/PurpleDevTools/Public/Get-CommentBasedHelp.ps1
@@ -17,6 +17,20 @@ Get the help comment for the command specified by the Name parameter.
 function Get-CommentBasedHelp {
     [CmdletBinding()]
     param (
+        [ArgumentCompleter({
+            [OutputType([System.Management.Automation.CompletionResult])]
+            param(
+                [string] $CommandName,
+                [string] $ParameterName,
+                [string] $WordToComplete,
+                [System.Management.Automation.Language.CommandAst] $CommandAst,
+                [System.Collections.IDictionary] $FakeBoundParameters
+            )
+            
+            $CommandList = Get-Command "$wordToComplete*"
+            
+            return $CommandList.Name
+        })]
         [Parameter(Mandatory,ValueFromPipeline,ValueFromPipelineByPropertyName)]
         [Alias('CommandName')]
         [String]$Name

--- a/PurpleDevTools/Public/Save-MarkdownHelp.ps1
+++ b/PurpleDevTools/Public/Save-MarkdownHelp.ps1
@@ -46,7 +46,35 @@ and description of the module.
 function Save-MarkdownHelp {
     [CmdletBinding(DefaultParameterSetName="Command")]
     param (
+        [ArgumentCompleter({
+            [OutputType([System.Management.Automation.CompletionResult])]
+            param(
+                [string] $CommandName,
+                [string] $ParameterName,
+                [string] $WordToComplete,
+                [System.Management.Automation.Language.CommandAst] $CommandAst,
+                [System.Collections.IDictionary] $FakeBoundParameters
+            )
+            
+            $CommandList = Get-Command "$wordToComplete*"
+            
+            return $CommandList.Name
+        })]
         [parameter(Mandatory,ValueFromPipeline,ParameterSetName="Command",Position=0)]$Command,
+        [ArgumentCompleter({
+            [OutputType([System.Management.Automation.CompletionResult])]
+            param(
+                [string] $CommandName,
+                [string] $ParameterName,
+                [string] $WordToComplete,
+                [System.Management.Automation.Language.CommandAst] $CommandAst,
+                [System.Collections.IDictionary] $FakeBoundParameters
+            )
+            
+            $ModuleList = Get-Module "$wordToComplete*"
+            
+            return $ModuleList.Name
+        })]
         [Parameter(Mandatory,ParameterSetName="Module")][string]$Module,
         [Parameter(Position=1)][ValidateScript({
             if (Test-Path -Path $_ -IsValid){

--- a/PurpleDevTools/Public/Save-XMLHelp.ps1
+++ b/PurpleDevTools/Public/Save-XMLHelp.ps1
@@ -32,7 +32,35 @@ using namespace System.XML
 function Save-XMLHelp {
     [CmdletBinding(DefaultParameterSetName="Command")]
     param (
+        [ArgumentCompleter({
+            [OutputType([System.Management.Automation.CompletionResult])]
+            param(
+                [string] $CommandName,
+                [string] $ParameterName,
+                [string] $WordToComplete,
+                [System.Management.Automation.Language.CommandAst] $CommandAst,
+                [System.Collections.IDictionary] $FakeBoundParameters
+            )
+            
+            $CommandList = Get-Command "$wordToComplete*"
+            
+            return $CommandList.Name
+        })]
         [parameter(Mandatory,ValueFromPipeline,ParameterSetName="Command",Position=0)]$Command,
+        [ArgumentCompleter({
+            [OutputType([System.Management.Automation.CompletionResult])]
+            param(
+                [string] $CommandName,
+                [string] $ParameterName,
+                [string] $WordToComplete,
+                [System.Management.Automation.Language.CommandAst] $CommandAst,
+                [System.Collections.IDictionary] $FakeBoundParameters
+            )
+            
+            $ModuleList = Get-Module "$wordToComplete*"
+            
+            return $ModuleList.Name
+        })]
         [Parameter(Mandatory,ParameterSetName="Module")][string]$Module,
         [Parameter(Mandatory,Position=1)][ValidateScript({
             if (Test-Path -Path $_ -IsValid -PathType Leaf){


### PR DESCRIPTION
Add completers to the command and module arguments. This provides a completer for Get-CommentBasedHelp, Save-XMLHelp and Save-MarkdownHelp.