### PR TITLE
Fix example missing empty line

### DIFF
--- a/PurpleDevTools/Public/Get-CommentBasedHelp.ps1
+++ b/PurpleDevTools/Public/Get-CommentBasedHelp.ps1
@@ -11,6 +11,7 @@ The name of the command to generate help for.
 
 .EXAMPLE
 Get-CommentBasedHelp -Name <String>
+
 Get the help comment for the command specified by the Name parameter.
 
 #>

--- a/PurpleDevTools/Public/Get-CommentBasedHelp.ps1
+++ b/PurpleDevTools/Public/Get-CommentBasedHelp.ps1
@@ -95,6 +95,7 @@ function Get-CommentBasedHelp {
                         if ($_.introduction){
                             $_.introduction.Text -join $DoubleNewLine
                         }
+                        '' # emtpy line between code and help
                         ($_.remarks.Text | where-Object {-not [string]::IsNullOrWhiteSpace($_) }) -join $DoubleNewLine
                     ) -join $NewLine
                 }
@@ -110,6 +111,7 @@ function Get-CommentBasedHelp {
                                 "<$($_.ParameterType.name)>"
                             }
                         ) -join ' '
+                        '' # emtpy line between code and help
                         "A description of how to use parameter set $($_.Name)"
                     ) -join $NewLine
                 }

--- a/PurpleDevTools/Public/New-ObjectListCommand.ps1
+++ b/PurpleDevTools/Public/New-ObjectListCommand.ps1
@@ -35,6 +35,7 @@ ie remove- and set- will not exist if unspecified.
 
 .Example
 New-ObjectListCommand -Class [test] -Path .\ -ListPath '$env:programdata\test.json'
+
 Uses the loaded type test as the base of the command templates. Function files will be saved to '.\',
 and the list save location will be '$env:programdata\test.json'.
 

--- a/PurpleDevTools/Public/New-ObjectListCommand.ps1
+++ b/PurpleDevTools/Public/New-ObjectListCommand.ps1
@@ -39,7 +39,6 @@ New-ObjectListCommand -Class [test] -Path .\ -ListPath '$env:programdata\test.js
 Uses the loaded type test as the base of the command templates. Function files will be saved to '.\',
 and the list save location will be '$env:programdata\test.json'.
 
-.Links
 
 #>
 function New-ObjectListCommand {

--- a/PurpleDevTools/Public/New-ProxyCommand.ps1
+++ b/PurpleDevTools/Public/New-ProxyCommand.ps1
@@ -11,10 +11,12 @@
 
 .EXAMPLE
     New-ProxyCommand -ProxiedCommand Get-Content -Name Get-ModifiedContent
+    
     Will output to the console the function definition to proxy the command Get-Content. The name of the function in the definition is Get-ModifiedContent.
 
 .EXAMPLE
     New-ProxyCommand -ProxiedCommand Get-Content -Name Get-ModifiedContent -OutFile .\myfile.ps1
+
     Will save to the specified file the function definition to proxy the command Get-Content. The name of the function in the definition is Get-ModifiedContent.
 
 .PARAMETER Command

--- a/PurpleDevTools/Public/Save-XMLHelp.ps1
+++ b/PurpleDevTools/Public/Save-XMLHelp.ps1
@@ -23,10 +23,12 @@ using namespace System.XML
 
 .EXAMPLE
     Save-XMLHelp -Command Get-Content -Path .\mymodule-help.xml
+    
     This will save the current help for the command Get-Content to the given file.
 
 .EXAMPLE
     Save-XMLHelp -Module MyModule -Path .\mymodule-help.xml
+
     This will save the help for all commands in the loaded module MyModule to the file. If the file is saved into the module, it should act as a valid Helpfile.
 #>
 function Save-XMLHelp {


### PR DESCRIPTION
The powershell help system requires a blank line after the code to be able to separate it from the remarks. The command was not providing these lines.

This fixes the command and existing help in this module.