### PR TITLE
Fix readme description section missing empty line.

### DIFF
--- a/PurpleDevTools/Public/Save-MarkdownHelp.ps1
+++ b/PurpleDevTools/Public/Save-MarkdownHelp.ps1
@@ -247,9 +247,11 @@ function Save-MarkdownHelp {
                     if ($ModuleObject.Description) {
                         $ModuleObject.Description
                     }
+                    "" #emtpy line before next section
 
                     if ($ModuleObject.PrivateData.PSData.ReleaseNotes) {
                         New-MarkdownSection -Name ReleaseNotes -Content $ModuleObject.PrivateData.PSData.ReleaseNotes
+                        "" #emtpy line before next section
                     }
                 }
 


### PR DESCRIPTION
index section description would not create a empty line after the description. Thus the next section was pushed against the description.